### PR TITLE
Switch from SweetAlert to SweetAlert2

### DIFF
--- a/example/App.vue
+++ b/example/App.vue
@@ -76,7 +76,7 @@
 
 <script>
     import Hljs from 'highlightjs';
-    import swal from 'sweetalert';
+    import swal from 'sweetalert2';
     import {
         usageScript,
         usageHTML,

--- a/example/main.sass
+++ b/example/main.sass
@@ -7,7 +7,7 @@
  */
 
 @import "~primer-css/build/build.css"
-@import "~sweetalert/dist/sweetalert.css"
+@import "~sweetalert2/dist/sweetalert2.css"
 @import "~highlightjs/styles/github.css"
 
 body

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "primer-css": "^6.0.0",
     "pug": "^2.0.0-rc.2",
     "sass-loader": "^6.0.5",
-    "sweetalert": "^1.1.3",
+    "sweetalert2": "^7.0.5",
     "vbuild": "^6.0.0",
     "vbuild-karma": "^1.0.0"
   },


### PR DESCRIPTION
I would like to propose to switch from SweetAlert to [SweetAlert2](https://github.com/sweetalert2/sweetalert2) - the supported fork of SweetAlert. The original reason for creating SweetAlert2 is inactivity of SweetAlert: https://stackoverflow.com/a/27842854/1331425 

### Reasons to switch:

1. Horizontal jumpiness issue, which doesn't exist in SweetAlert2:

![recorded](https://user-images.githubusercontent.com/6059356/33235230-6d3036f2-d23c-11e7-96f5-a517fb17dd45.gif)

2. Accessibility (WAI-ARIA) - SweetAlert2 is fully WAI-ARIA compatible and supports all popular screen-readers. Accessibility is a must in 2017, there are a lot of explanatory and tech articles, but this one is truly inspirable: [Software development 450 words per minute](https://www.vincit.fi/en/blog/software-development-450-words-per-minute/)

3. Better support, average time to resolve an issue:

   - SweetAlert: ![](http://isitmaintained.com/badge/resolution/t4t5/sweetalert.svg)
   - SweetAlert2: ![](http://isitmaintained.com/badge/resolution/sweetalert2/sweetalert2.svg)

4. SweetAlert2 is more popular that SweetAlert:

   - SweetAlert: ![](https://img.shields.io/npm/dm/sweetalert.svg)
   - SweetAlert2: ![](https://img.shields.io/npm/dm/sweetalert2.svg)
  